### PR TITLE
Expanding pools & more

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,11 +111,11 @@ The `Dispatcher` manages two resource pools: one for available `Fiber`s and anot
 - Scheduler algorightm to detect & mitigate fiber exhaustion
 - Performance profiling
 - Valgrind
-- Add a Yield() call to the Dispatcher. Acts like the WaitForJob(), except it doesn't poll on spinlock, it simply starts up the scheduler again.
-- Add a flag (and logic) to allow resource pools to grow when they're below a specific threshold
 - Add an optional timeout vailute to `Dispatcher::WaitForJob()`
 - Add a new IMGui-based demo, visualizing queues and adding buttons to manage running jobs
 - Full documentation
+- Full test coverage
+
 
 
 # Additional Reading

--- a/examples/basic/basic.cpp
+++ b/examples/basic/basic.cpp
@@ -27,7 +27,6 @@ void JobFunction(void* pUserData) {
 
 int main()
 {
-    Job job(JobFunction, nullptr);
 
     std::cout << "Starting Scheduler" << std::endl;
     if (Dispatcher::GetInstance().Init() == false) {

--- a/examples/basic/basic.cpp
+++ b/examples/basic/basic.cpp
@@ -29,7 +29,7 @@ int main()
 {
 
     std::cout << "Starting Scheduler" << std::endl;
-    if (Dispatcher::GetInstance().Init() == false) {
+    if (Dispatcher::GetInstance().Init(100, 100) == false) {
         std::cout << "Failed: " << Dispatcher::GetInstance().GetLastError() << std::endl;
         return -1;
     }
@@ -45,16 +45,16 @@ int main()
 
         switch (std::stoi(input)) {
         case 1:
-            std::cout << "Adding 1 jobs to queue";
+            std::cout << "Adding 300 jobs to queue";
 
-            for (auto x = 0; x < 1; x++)
+            for (auto x = 0; x < 300; x++)
                 Dispatcher::GetInstance().AddJob(JobFunction, nullptr);
 
             break;
         case 2:
-            std::cout << "Adding 300 jobs to queue";
+            std::cout << "Adding 3000 jobs to queue";
 
-            for (auto x = 0; x < 300; x++)
+            for (auto x = 0; x < 3000; x++)
                 Dispatcher::GetInstance().AddJob(JobFunction, nullptr);
 
             break;

--- a/include/hustle/Dispatcher.h
+++ b/include/hustle/Dispatcher.h
@@ -12,9 +12,10 @@
 #include <map>
 
 namespace Hustle {
+
 	class Dispatcher {
 	public:
-		const static int FiberPoolSize = 1000;
+		const static int FiberPoolSize = 100;
 		const static int JobPoolSize = 10000;
 
 		static Dispatcher& GetInstance() {

--- a/include/hustle/Dispatcher.h
+++ b/include/hustle/Dispatcher.h
@@ -14,25 +14,68 @@
 namespace Hustle {
 
 	class Dispatcher {
-	public:
-		const static int FiberPoolSize = 100;
-		const static int JobPoolSize = 10000;
+	public:		
 
 		static Dispatcher& GetInstance() {
 			static Dispatcher instance;
 			return instance;
 		}
 
-		bool Init(int iWorkerThreadCount = -1);
+		/**
+		 * @brief Initialize the job system. Only to be called once.
+		 * @param iFiberPoolSize - The number of fibers to allocate in fiber pool
+		 * @param iJobPoolSize - The number of items to allocate in the job pool
+		 * @param iWorkerThreadCount - The number of worker threads to allocate. -1 for one thread per logical core.
+		 * @return
+		*/
+		bool Init(int iFiberPoolSize, int iJobPoolSize, int iWorkerThreadCount = -1);
+
+		/**
+		 * @brief Stop the job system. All pools will be destroyed.
+		*/
 		void Shutdown();
 
+		/**
+		 * @brief The number of worker threads (one per logical core) that are running.
+		 * @return Thread count
+		*/
 		int WorkerThreadCount() { return m_iWorkerThreadCount; }
-
+		
+		/**
+		 * @brief Put a new job onto the global queue
+		 * @param entryPoint - Function to invoke for the job
+		 * @param pUserData - A pointer to data that will be passed into the entry point function
+		 * @return - Handle to the queued job
+		*/
 		JobHandle AddJob(JobEntryPoint entryPoint, void* pUserData);
+
+		/**
+		 * @brief - Poll for the job to reach completion. Will not return until the specified job is complete.
+		 * @param hJob - Handle for the job to poll for completion
+		*/
 		void WaitForJob(JobHandle hJob);
 
+		/**
+		 * @brief If in a job, give execution control back to the scheduler. If called outside a job, invoke the system Yield().
+		*/
+		void YieldToScheduler();
+
+		/**
+		 * @brief Query the current number of items in the job queue
+		 * @return The current number of items in the job queue 
+		*/
 		size_t GetJobQueueDepth() { return m_Jobs.Size(); }
+
+		/**
+		 * @brief Query the current number of free jobs in the job pool
+		 * @return Free job count
+		*/
 		size_t GetFreeJobCount() { return m_JobPool.GetFreeCount(); }
+
+		/**
+		 * @brief Query the total number of jobs in the job pool
+		 * @return Total job pool item count
+		*/
 		size_t GetFreeJobTotal() { return m_JobPool.GetTotalCount(); }
 
 #ifdef _DEBUG
@@ -42,31 +85,25 @@ namespace Hustle {
 
 		size_t GetFiberPoolTotal() { return m_FiberPool.GetTotalCount(); }
 		size_t GetFiberPoolFree() { return m_FiberPool.GetFreeCount(); }
-		Fiber* GetCurrentFiber();
 
 		std::string GetLastError() { return m_LastError; }
 
 	private:
 		Dispatcher();
-
-		// Main loop for the threads (which will be converted to a fibers)
 		static DWORD WINAPI Scheduler(LPVOID pData);
-
-		ResourcePool<Fiber, FiberPoolSize>	m_FiberPool;
-
-		// A map of the fibers, keyed on the pointer returned by CreateFiber()
-		// This allows us to call the Win32 GetCurrentFiber() function and grab the Fiber object. 
-		std::map<void*, Fiber*>	m_FiberMap;
-
+		
 		int m_iWorkerThreadCount;
 		WorkerThread* m_pWorkerThreads;
-		std::atomic<uint32_t> m_RunningThreads = { 0 };
+		std::atomic<uint32_t> m_RunningThreads;
+
+		// Pool of available fibers
+		ResourcePool<Fiber>	m_FiberPool;
 
 		// Queue of jobs to run
 		LockedQueue<Job*> m_Jobs;
 
 		// The pool of Job objects to use for scheduling
-		ResourcePool<Job, JobPoolSize> m_JobPool;
+		ResourcePool<Job> m_JobPool;
 
 		// Holds any errors that occur by the scheduler or worker threads.
 		std::string m_LastError;

--- a/include/hustle/Fiber.h
+++ b/include/hustle/Fiber.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <map>
 #include <windows.h>
 
 namespace Hustle {
@@ -26,6 +27,8 @@ namespace Hustle {
 		Job* CurrentJob() { return m_pJob; }
 		void* GetFiberHandle() { return m_hFiber; }
 
+		static Fiber* Fiber::GetCurrentFiber();
+
 		void SwitchTo() { ::SwitchToFiber(m_hFiber); }
 
 	private:
@@ -43,5 +46,9 @@ namespace Hustle {
 
 		// Current job being executed
 		Job* m_pJob;
+
+		// A map of the fibers, keyed on the pointer returned by CreateFiber()
+		// This allows us to call the Win32 GetCurrentFiber() function and grab the Fiber object. 
+		static std::map<void*, Fiber*>	s_FiberMap;
 	};
 }

--- a/include/hustle/Job.h
+++ b/include/hustle/Job.h
@@ -8,7 +8,17 @@ namespace Hustle {
 
 	class Job : public SpinLock {
 	public:
-		Job() = default;
+		Job() :
+			m_pUserData(nullptr),
+			m_JobEntrypoint(nullptr) {
+		}
+		
+		Job(const Job&) = default;
+
+		/*Job& operator=(const Job&) {
+			return Job();
+		}*/
+
 		Job(JobEntryPoint entryPoint, void* pUserData = nullptr) :
 			m_JobEntrypoint(entryPoint),
 			m_pUserData(pUserData) {

--- a/include/hustle/LockedQueue.h
+++ b/include/hustle/LockedQueue.h
@@ -11,6 +11,7 @@ namespace Hustle {
 		void Push(T val) {
 			Lock();
 			m_Queue.push(val);
+			
 			Unlock();
 		}
 
@@ -39,4 +40,5 @@ namespace Hustle {
 	private:
 		std::queue<T>	m_Queue;
 	};
+
 }

--- a/include/hustle/ResourcePool.h
+++ b/include/hustle/ResourcePool.h
@@ -1,55 +1,116 @@
 #pragma once
 
+#include "LockedQueue.h"
+
 #include <assert.h>
 #include <atomic>
 #include <queue>
-#include "LockedQueue.h"
 
 namespace Hustle {
+
 	template<class T, int iCount>
 	class ResourcePool {
 	public:
+
+		/**
+		 * @brief Default constructor for the ResourcePool. 
+		*/
 		ResourcePool() :
+			m_fGrowthFactor(0.0f),
+			m_iInUseCounter(0),
 			m_pPool(nullptr),
 			m_iResourcCount(0) {
 
 			m_iResourcCount = iCount;
-			m_pPool = new T[iCount];
 
 			// Add all of the newly allocated items to the queue
-			for (int i = 0; i < m_iResourcCount; i++)
-				m_FreeResources.Push(&m_pPool[i]);
+			for (int i = 0; i < m_iResourcCount; i++) {
+				T* pResource = new T();
+				m_Pool.push_back(pResource);
+				m_FreeResources.Push(pResource);
+			}
 		}
-
+		
 		~ResourcePool() {
-			delete[] m_pPool;
+
+			// Delete all of the resources
+			for (auto pResource : m_Pool)
+				delete pResource;
+			
+			// Empty out the pool
+			m_Pool.clear();
+
 		}
 
+		/**
+		 * @brief Obtain a single resorce from the pool
+		 * @return A pointer to the resource (T)
+		*/
 		T* Get() {
 			
 			T* pResource = nullptr;
 			pResource = m_FreeResources.Pop();
 
-#ifdef _DEBUG 
-			// Only increment the lock if there was an available resource
 			if (pResource) {
-				m_StatsLock.Lock();
 				m_iInUseCounter++;
-				if (m_iInUseCounter > m_iHighWaterMark)
-					m_iHighWaterMark = m_iInUseCounter;
-				m_StatsLock.Unlock();
+
+				// Only called in DEBUG mode
+				HighWaterCheck();
+			} else {
+
+				// Are we allowing dynamic pool resizing?
+				if (m_fGrowthFactor > 0.0f) {		
+
+					// Take the resize lock
+					m_ResizeLock.Lock();
+
+					// What if...the resize alredy occured somewhere else?
+					pResource = m_FreeResources.Pop();
+
+					// Got one - great!
+					if (pResource) {
+						m_iInUseCounter++;
+
+						// Only called in DEBUG mode
+						HighWaterCheck();
+
+						m_ResizeLock.Unlock();
+						return pResource;
+					}
+
+					// Still nothing available - let's grow the pool
+					int iItemsToGrow = m_iResourcCount * m_fGrowthFactor;
+					for (auto i = 0; i < iItemsToGrow; i++) {
+						T* pResource = new T();
+						m_Pool.push_back(pResource);
+						m_FreeResources.Push(pResource);
+						m_iResourcCount++;
+					}
+
+					m_ResizeLock.Unlock();
+
+					// Alright...get one for real this time
+					pResource = m_FreeResources.Pop();
+
+					// Got one - great!
+					if (pResource) {
+						m_iInUseCounter++;
+
+						// Only called in DEBUG mode
+						HighWaterCheck();
+
+						return pResource;
+					}
+				}
 			}
-#endif
+			
 
 			return pResource;
 		}
 
 		void Release(T* pResource) {
 
-#ifdef _DEBUG 
 			m_iInUseCounter--;
-#endif
-
 			m_FreeResources.Push(pResource);
 		}
 
@@ -59,10 +120,29 @@ namespace Hustle {
 			return m_FreeResources.Size();
 		}
 
-		// Allow caller to access the resource array by index
-		T* operator [](int i) { return &(m_pPool[i]); }
+		float GetGrowthFactor() {
+			return m_fGrowthFactor;
+		}
+
+		void SetGrowthFactor(float fFactor) {
+			m_fGrowthFactor = fFactor;
+		}
+
+		/**
+		 * @brief Array operator to allow for direct access to the entire pool (use at your own risk)
+		 * @param i Index of the pool item to access
+		 * @return A pointer to the pool item (T)
+		*/
+		T* operator [](int i) { 
+			return m_Pool[i];
+		}
 
 #ifdef _DEBUG 
+
+		/**
+		 * @brief Fetch the highest number of outstanding items requested from the pool. Only available in debug builds.
+		 * @return Highest number of items resuqested by the application
+		*/
 		int GetHighWaterMark() {
 			int iHighWaterMark = 0;
 			m_StatsLock.Lock();
@@ -70,20 +150,42 @@ namespace Hustle {
 			m_StatsLock.Unlock();
 			return iHighWaterMark;
 		}
+#else 
+		/**
+		 * @brief Not availbale in release mode.
+		 * @return N/A
+		*/
+		int GetHighWaterMark() { return 0; }
 #endif
 
 	private:
 
 		T* m_pPool;
 		int m_iResourcCount;
+		float m_fGrowthFactor;
 
-		// Performance metrics (only available in debug builds)
-#ifdef _DEBUG 
+		std::vector<T*> m_Pool;				// Vector of every allocated resource
+		LockedQueue<T*> m_FreeResources;	// Holds all available resources
+		SpinLock m_ResizeLock;				// Taken when a pool resize is underway
+
+		// Performance metrics
 		SpinLock m_StatsLock;
 		int m_iHighWaterMark = { 0 };
-		int m_iInUseCounter = { 0 };
-#endif
-		LockedQueue<T*> m_FreeResources;
+		std::atomic<int> m_iInUseCounter;
 
+		// Performance methods that are only available/called if running in DEBUG mode
+#ifdef _DEBUG
+		void HighWaterCheck() {
+			// Only increment the lock if there was an available resource
+
+			// TODO: Is there a way to do this without locking?
+			m_StatsLock.Lock();
+			if (m_iInUseCounter > m_iHighWaterMark)
+				m_iHighWaterMark = m_iInUseCounter;
+			m_StatsLock.Unlock();			
+		}
+#else
+		void HighWaterCheck(void *pItem) {}
+#endif
 	};
 }

--- a/include/hustle/ResourcePool.h
+++ b/include/hustle/ResourcePool.h
@@ -81,8 +81,7 @@ namespace Hustle {
 
 					m_ResizeLock.Unlock();
 
-					// Bump our counters
-					
+					// Bump our counters					
 					m_iInUseCounter++;
 
 					// Only called in DEBUG mode
@@ -91,7 +90,7 @@ namespace Hustle {
 			}			
 
 			return pResource;
-		}
+		} // end of ResourcePool::Get()
 
 		void Release(T* pResource) {
 

--- a/src/Dispatcher.cpp
+++ b/src/Dispatcher.cpp
@@ -10,6 +10,9 @@ namespace Hustle {
 
 	bool Dispatcher::Init(int iWorkerThreadCount) {
 
+		// Set a growth factor on the fiber pool
+		m_FiberPool.SetGrowthFactor(10);
+
 		bool bReturn = true;
 		// Create a hash map of the Fiber objects, keyed off of the OS fiber handle. 
 		for (int i = 0; i < Dispatcher::FiberPoolSize; i++)

--- a/src/Fiber.cpp
+++ b/src/Fiber.cpp
@@ -7,6 +7,7 @@
 
 namespace Hustle {
 
+	
 	Fiber::Fiber() :
 		m_pJob(nullptr),
 		m_hFiber(nullptr),
@@ -37,7 +38,8 @@ namespace Hustle {
 		if (m_hFiber)
 			DeleteFiber(m_hFiber);
 	}
-
+	
+	
 	void Fiber::Activate(Job* pJob, Fiber* pParent) {
 
 		// The thread that we'll switch back to when the job is complete

--- a/tests/ResourcePool.cpp
+++ b/tests/ResourcePool.cpp
@@ -14,7 +14,8 @@ TEST(ResourcePool, FreeCount) {
 	};
 
 
-	ResourcePool<TestResource, MaxPoolSize> testPool;
+	ResourcePool<TestResource> testPool;
+	testPool.Grow(MaxPoolSize);
 	EXPECT_EQ(testPool.GetFreeCount(), MaxPoolSize);
 	EXPECT_EQ(testPool.GetTotalCount(), MaxPoolSize);
 

--- a/tests/ResourcePool.cpp
+++ b/tests/ResourcePool.cpp
@@ -13,7 +13,6 @@ TEST(ResourcePool, FreeCount) {
 		int iSomething;
 	};
 
-
 	ResourcePool<TestResource> testPool;
 	testPool.Grow(MaxPoolSize);
 	EXPECT_EQ(testPool.GetFreeCount(), MaxPoolSize);
@@ -40,4 +39,84 @@ TEST(ResourcePool, FreeCount) {
 	// Verify counts
 	EXPECT_EQ(testPool.GetFreeCount(), MaxPoolSize);
 	EXPECT_EQ(testPool.GetTotalCount(), MaxPoolSize);
+}
+
+TEST(ResourcePool, IncreasePoolCount) {
+
+	struct TestResource {
+		int iSomething;
+	};
+
+	ResourcePool<TestResource> testPool;
+	EXPECT_EQ(testPool.GetTotalCount(), 0);
+	EXPECT_EQ(testPool.GetFreeCount(), 0);
+	auto newSize = testPool.Grow(MaxPoolSize);
+	EXPECT_EQ(newSize, MaxPoolSize);
+
+	newSize = testPool.Grow(MaxPoolSize);
+	EXPECT_EQ(newSize, MaxPoolSize * 2);
+	EXPECT_EQ(testPool.GetFreeCount(), MaxPoolSize * 2);
+	EXPECT_EQ(testPool.GetTotalCount(), MaxPoolSize * 2);
+}
+
+TEST(ResourcePool, PoolAutoGrow) {
+
+	struct TestResource {
+		int iSomething;
+	};
+
+	float fGrowthFactor = 1.5f;
+	ResourcePool<TestResource> testPool;
+	testPool.SetGrowthFactor(fGrowthFactor);
+	EXPECT_EQ(testPool.GetGrowthFactor(), fGrowthFactor);
+
+	// Start with 5 resources
+	EXPECT_EQ(testPool.Grow(5), 5);
+
+	TestResource* pResources[5];
+
+	// Get the 5 resources, which should cause the pool to grow by 1.5 times.
+	for (int i = 0; i < 5; i++) {
+		pResources[i] = testPool.Get();
+		EXPECT_EQ(testPool.GetFreeCount(), 5 - (i + 1));
+	}
+	
+	// Grab one more resource that will trigger the resize (since there are none left)
+	auto pResource = testPool.Get();
+	assert(pResource != nullptr);
+
+	// Initial size (5) + 1.5 times the initial size (7) = 12	
+	EXPECT_EQ(testPool.GetTotalCount(), 12);
+	EXPECT_EQ(testPool.GetFreeCount(), 6);
+
+	// Release the (kraken?) resources
+	testPool.Release(pResource);
+	for (int i = 0; i < 5; i++)
+		testPool.Release(pResources[i]);
+	
+	EXPECT_EQ(testPool.GetTotalCount(), 12);
+	EXPECT_EQ(testPool.GetFreeCount(), 12);
+
+}
+
+TEST(ResourcePool, ArrayOperator) {
+
+	struct TestResource {
+		int iIndex;
+	};
+
+	ResourcePool<TestResource> testPool;
+	testPool.Grow(5);
+
+	// Grab 5 resources, set their index to match the loop counter
+	for (int i = 0; i < 5; i++) {
+		TestResource* pResource = testPool.Get();
+		pResource->iIndex = i;
+	}
+
+	for (int i = 0; i < 5; i++) {
+		TestResource* pResource = testPool[i];
+		EXPECT_EQ(pResource->iIndex, i);
+	}
+	
 }


### PR DESCRIPTION
This PR allow for pools to increase in size. 

Rather than having the fiber and job pools remain static in size, it would be helpful if they could expand when becoming exhausted. The `ResourcePool` class no longer takes a template initializer but instead, requires a call to `Grow()` to create the initial pool of resources. 

The "Fiber Map" that was previously part of the `Dispatcher` is now a static value directly within the `Fiber` class. 

Lastly, a new `YieldToScheduler` method was added to the `Dispatcher`. When called from within a job, execution control will be ceded back to the controller. When called from outside the context of a scheduler thread, the systems `Yield()` function is invoked. 

In addition, some unit tests were added as well as starting an effort to comment all of the things!

